### PR TITLE
Add curated repos to liquid directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A curated list of Liquid Network resources, libraries, tools and applications. L
 - [Liquid.network](https://liquid.network/) - Mempool.space liquid network explorer
 - [electrs-liquid-umbrel](https://github.com/4rkad/electrs-liquid-umbrel)![stars](https://img.shields.io/github/stars/4rkad/electrs-liquid-umbrel.svg?style=social) - Electrum server for the Liquid Network — Umbrel community app
 - [Enciclopedia](https://github.com/lvaccaro/enciclopedia-rust) - Web-based asset information explorer for the Liquid Network
-- [asset_registry_v2](https://github.com/Blockstream/asset_registry_v2)![stars](https://img.shields.io/github/stars/Blockstream/asset_registry_v2.svg?style=social) - Asset Registry v2
 
 ## Network 
 - [Liquid.net Statistics](https://liquid.net/) - Network statistics and monitoring dashboard  
@@ -38,6 +37,7 @@ A curated list of Liquid Network resources, libraries, tools and applications. L
 ## Liquid Network Asset
 #### Mainnet
 - [Asset Registry JSON](https://assets.blockstream.info/) - Official Blockstream asset registry
+- [asset_registry_v2](https://github.com/Blockstream/asset_registry_v2)![stars](https://img.shields.io/github/stars/Blockstream/asset_registry_v2.svg?style=social) - Source code for the official Liquid Asset Registry (powers the Asset Registry JSON above)
 - [anchor](https://github.com/0ceanSlim/anchor)![stars](https://img.shields.io/github/stars/0ceanSlim/anchor.svg?style=social) - Immutable, permissionless constant-product AMM for Liquid
 - [Production Assets List](https://blockstream.info/liquid/assets) - Human-readable list of all assets
 - [Blockstream AMP](https://blockstream.com/amp/) - Asset management platform for institutions

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated list of Liquid Network resources, libraries, tools and applications. L
 - [Liquid.network](https://liquid.network/) - Mempool.space liquid network explorer
 - [electrs-liquid-umbrel](https://github.com/4rkad/electrs-liquid-umbrel)![stars](https://img.shields.io/github/stars/4rkad/electrs-liquid-umbrel.svg?style=social) - Electrum server for the Liquid Network — Umbrel community app
 - [Enciclopedia](https://github.com/lvaccaro/enciclopedia-rust) - Web-based asset information explorer for the Liquid Network
+- [asset_registry_v2](https://github.com/Blockstream/asset_registry_v2)![stars](https://img.shields.io/github/stars/Blockstream/asset_registry_v2.svg?style=social) - Asset Registry v2
 
 ## Network 
 - [Liquid.net Statistics](https://liquid.net/) - Network statistics and monitoring dashboard  


### PR DESCRIPTION
## Curated Repository Additions

Added 1 repository candidate(s), placed into matching README sections rather than appended as a bulk dump.

- Blockstream/asset_registry_v2

## Safety checks
- Entries are inserted into existing sections only.
- Bulk PRs over 12 repositories are refused by the helper script.
- Unclassified repositories are skipped instead of being appended to the end.

---
*Auto-discovered by the awesome-directory-updater bot; conservatively categorized by create-directory-pr.py.*